### PR TITLE
H2GIS module

### DIFF
--- a/DBI/pom.xml
+++ b/DBI/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.renjin.cran</groupId>
 		<artifactId>dbiparent</artifactId>
-		<version>0.3-SNAPSHOT</version>
+		<version>0.3.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>DBI</artifactId>
@@ -24,10 +24,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.5</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/MonetDB.R/pom.xml
+++ b/MonetDB.R/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.renjin.cran</groupId>
         <artifactId>dbiparent</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/RH2GIS/NAMESPACE
+++ b/RH2GIS/NAMESPACE
@@ -1,0 +1,3 @@
+import(DBI)
+importClass(org.h2.Driver)
+exportPattern("^[^\\.]")

--- a/RH2GIS/pom.xml
+++ b/RH2GIS/pom.xml
@@ -2,36 +2,29 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>dbiparent</artifactId>
         <groupId>org.renjin.cran</groupId>
+        <artifactId>dbiparent</artifactId>
         <version>0.3.1-SNAPSHOT</version>
     </parent>
-    <organization>
+    <artifactId>RH2GIS</artifactId>
+    <packaging>jar</packaging>
+	<organization>
         <name>CNRS</name>
         <url>http://www.orbisgis.org</url>
     </organization>
 
-    <artifactId>RH2</artifactId>
-
-    <name>RH2</name>
-    <description>RH2 connects H2 database and Renjin via a DBI-like interface</description>
-    <packaging>jar</packaging>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
-    <dependencies>        
+<dependencies>        
         <dependency>
             <groupId>org.renjin.cran</groupId>
             <artifactId>DBI</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.192</version>
-        </dependency>
+        </dependency>        
+	<dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>h2gis-ext</artifactId>
+            <version>1.3.0</version>
+            <type>jar</type>
+	</dependency>
     </dependencies>
 
     <build>
@@ -43,5 +36,4 @@
         </plugins>
     </build>
 
-   
 </project>

--- a/RH2GIS/src/main/R/h2gis.R
+++ b/RH2GIS/src/main/R/h2gis.R
@@ -4,3 +4,14 @@ RH2GIS <- H2GIS <- function() {
 
 # load DBI to replicate GNU R 'Depends:'
 .onLoad <- function(libname, pkgname) library(DBI)
+
+
+loadSpatialFunctions <- function(con){
+    if(dbIsValid(con)){
+        dbSendQuery(con,"CREATE ALIAS IF NOT EXISTS H2GIS_EXTENSION FOR \"org.h2gis.ext.H2GISExtension.load\";")
+        dbSendQuery(con,"CALL H2GIS_EXTENSION()")
+        
+        return ("H2GIS functions have been successfully loaded.")
+    }
+        return ("The connection is not valid. Cannot load H2GIS functions")
+}

--- a/RH2GIS/src/main/R/h2gis.R
+++ b/RH2GIS/src/main/R/h2gis.R
@@ -6,6 +6,7 @@ RH2GIS <- H2GIS <- function() {
 .onLoad <- function(libname, pkgname) library(DBI)
 
 
+#This function load the H2GIS spatial functions
 loadSpatialFunctions <- function(con){
     if(dbIsValid(con)){
         dbSendQuery(con,"CREATE ALIAS IF NOT EXISTS H2GIS_EXTENSION FOR \"org.h2gis.ext.H2GISExtension.load\";")

--- a/RH2GIS/src/main/R/h2gis.R
+++ b/RH2GIS/src/main/R/h2gis.R
@@ -1,0 +1,6 @@
+RH2GIS <- H2GIS <- function() {
+	JDBC(Driver$new(), "H2GIS")
+} 
+
+# load DBI to replicate GNU R 'Depends:'
+.onLoad <- function(libname, pkgname) library(DBI)

--- a/RH2GIS/src/test/R/h2gis-test.R
+++ b/RH2GIS/src/test/R/h2gis-test.R
@@ -2,7 +2,8 @@ library(hamcrest)
 library(RH2GIS)
 
 test.driver <- function() {
-	con <- dbConnect(RH2GIS(), url="jdbc:h2:file:/tmp/db", username="sa", password="")
+        dbPath = paste ("jdbc:h2:file:",tempdir(), "/db", sep = "", collapse = NULL)
+	con <- dbConnect(RH2GIS(), url=dbPath, username="sa", password="")
 	print(loadSpatialFunctions(con));
         sq <- dbSendQuery(con,"DROP TABLE IF EXISTS VANNES; CREATE TABLE VANNES (the_geom geometry, id int)")
         stopifnot(identical(dbExistsTable(con,"VANNES"),TRUE))

--- a/RH2GIS/src/test/R/h2gis-test.R
+++ b/RH2GIS/src/test/R/h2gis-test.R
@@ -3,8 +3,9 @@ library(RH2GIS)
 
 test.driver <- function() {
 	con <- dbConnect(RH2GIS(), url="jdbc:h2:file:/tmp/db", username="sa", password="")
-	sq <- dbSendQuery(con,"CREATE ALIAS IF NOT EXISTS H2GIS_EXTENSION FOR \"org.h2gis.ext.H2GISExtension.load\";")
-        sq <- dbSendQuery(con,"CALL H2GIS_EXTENSION()")
+	print(loadSpatialFunctions(con));
         sq <- dbSendQuery(con,"DROP TABLE IF EXISTS VANNES; CREATE TABLE VANNES (the_geom geometry, id int)")
         stopifnot(identical(dbExistsTable(con,"VANNES"),TRUE))
+        sq <- dbSendQuery(con,"INSERT INTO VANNES VALUES('POINT(0 1)'::GEOMETRY, 1)"); 
+        sq <- dbSendQuery(con,"SELECT ST_BUFFER(the_geom, 20) as the_geom FROM VANNES");
 }

--- a/RH2GIS/src/test/R/h2gis-test.R
+++ b/RH2GIS/src/test/R/h2gis-test.R
@@ -6,6 +6,6 @@ test.driver <- function() {
 	print(loadSpatialFunctions(con));
         sq <- dbSendQuery(con,"DROP TABLE IF EXISTS VANNES; CREATE TABLE VANNES (the_geom geometry, id int)")
         stopifnot(identical(dbExistsTable(con,"VANNES"),TRUE))
-        sq <- dbSendQuery(con,"INSERT INTO VANNES VALUES('POINT(0 1)'::GEOMETRY, 1)"); 
-        sq <- dbSendQuery(con,"SELECT ST_BUFFER(the_geom, 20) as the_geom FROM VANNES");
+        sq <- dbSendQuery(con,"INSERT INTO VANNES VALUES('POLYGON ((100 300, 210 300, 210 200, 100 200, 100 300))'::GEOMETRY, 1)"); 
+        stopifnot(identical(as.numeric(dbGetQuery(con,"SELECT ST_AREA(the_geom) as the_geom FROM VANNES")[[1]]),11000))
 }

--- a/RH2GIS/src/test/R/h2gis-test.R
+++ b/RH2GIS/src/test/R/h2gis-test.R
@@ -1,0 +1,10 @@
+library(hamcrest)
+library(RH2GIS)
+
+test.driver <- function() {
+	con <- dbConnect(RH2GIS(), url="jdbc:h2:file:/tmp/db", username="sa", password="")
+	sq <- dbSendQuery(con,"CREATE ALIAS IF NOT EXISTS H2GIS_EXTENSION FOR \"org.h2gis.ext.H2GISExtension.load\";")
+        sq <- dbSendQuery(con,"CALL H2GIS_EXTENSION()")
+        sq <- dbSendQuery(con,"DROP TABLE IF EXISTS VANNES; CREATE TABLE VANNES (the_geom geometry, id int)")
+        stopifnot(identical(dbExistsTable(con,"VANNES"),TRUE))
+}

--- a/RMySQL/pom.xml
+++ b/RMySQL/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
         <groupId>org.renjin.cran</groupId>
         <artifactId>dbiparent</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
 	<packaging>jar</packaging>
 

--- a/ROracle/pom.xml
+++ b/ROracle/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.renjin.cran</groupId>
         <artifactId>dbiparent</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
 

--- a/RPostgreSQL/pom.xml
+++ b/RPostgreSQL/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.renjin.cran</groupId>
         <artifactId>dbiparent</artifactId>
-        <version>0.3-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
 	<packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.renjin.cran</groupId>
     <artifactId>dbiparent</artifactId>
-    <version>0.3-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <url>http://monetr.r-forge.r-project.org/</url>


### PR DESCRIPTION
This PR adds new module called RH2GIS to facilitate the connection between Renjin and H2 with its spatial extension H2GIS. It solves dependency issues and add a function to load spatial H2GIS extension. 
