### PR TITLE
About #10

### DIFF
--- a/DBI/src/main/R/dbi.R
+++ b/DBI/src/main/R/dbi.R
@@ -134,7 +134,7 @@ dbExistsTable.JDBCConnection <- function(con, name, ...) {
 }
 
 dbListTables.JDBCConnection <- function(con) {
-	JDBCUtils$getTables(con$conn)	
+	JDBCUtils$getTables(con$conn,c("TABLE") )
 }
 
 dbBegin.JDBCConnection <- function(con, ...) {

--- a/DBI/src/main/java/org/renjin/cran/DBI/JDBCUtils.java
+++ b/DBI/src/main/java/org/renjin/cran/DBI/JDBCUtils.java
@@ -16,153 +16,198 @@ import org.renjin.primitives.vector.RowNamesVector;
 import org.renjin.sexp.ListVector;
 import org.renjin.sexp.StringVector;
 
+/**
+ * 
+ * Utilities to query a database using JDBC API
+ * 
+ * @author Hannes Mühleisen
+ * @author Erwan Bocher
+ */
 public class JDBCUtils {
+    
 
-  public static boolean hasCompleted(ResultSet rs) {
-    try {
-      return (rs.isClosed() || rs.isAfterLast());
-    } catch (SQLException e) {
-      return false;
-    }
-  }
-
-  public static StringVector getTables(Connection con) {
-    try {
-      StringVector.Builder sb = new StringVector.Builder();
-      DatabaseMetaData dbm = con.getMetaData();
-      String[] types = { "TABLE" };
-      ResultSet rsm = dbm.getTables(con.getCatalog(), null, null, types);
-
-      while (rsm.next()) {
-        sb.add(rsm.getString("TABLE_NAME"));
-      }
-      rsm.close();
-      return sb.build();
-    } catch (SQLException e) {
-      throw new EvalException(e);
-    }
-  }
-
-  public static StringVector getColumns(Connection con, String table) {
-    try {
-      StringVector.Builder sb = new StringVector.Builder();
-      DatabaseMetaData dbm = con.getMetaData();
-      ResultSet rsm = dbm.getColumns(con.getCatalog(), null, table, null);
-      while (rsm.next()) {
-        sb.add(rsm.getString("COLUMN_NAME"));
-      }
-      rsm.close();
-      // try again with an uppercased table name. Hello, Oracle!
-      if (sb.length() < 1) {
-        rsm = dbm.getColumns(con.getCatalog(), null, table.toUpperCase(), null);
-        while (rsm.next()) {
-          sb.add(rsm.getString("COLUMN_NAME"));
+    /**
+     * Check is the ResultSet is closed or if the cursor is after the last row.
+     *
+     * @param rs
+     * @return boolean
+     */
+    public static boolean hasCompleted(ResultSet rs) {
+        try {
+            return (rs.isClosed() || rs.isAfterLast());
+        } catch (SQLException e) {
+            return false;
         }
-        rsm.close();
-      }
-      return sb.build();
-    } catch (SQLException e) {
-      throw new EvalException(e);
     }
-  }
 
-  public static ListVector columnInfo(ResultSet rs) {
-    try {
-      ListVector.Builder tv = new ListVector.Builder();
-      ResultSetMetaData rsm = rs.getMetaData();
-      for (int i = 1; i < rsm.getColumnCount() + 1; i++) {
-        ListVector.NamedBuilder cv = new ListVector.NamedBuilder();
-        cv.add("name", rsm.getColumnName(i));
-        cv.add("type", rsm.getColumnTypeName(i));
-        tv.add(cv.build());
-      }
-      return tv.build();
-    } catch (SQLException e) {
-      throw new EvalException(e);
-    }
-  }
+    /**
+     * List the tables stored in the database
+     *
+     * @param con the connection to the database
+     * @param types Array of strings to set the table types
+     * @return StringVector
+     */
+    public static StringVector getTables(Connection con, String[] types) {
+        try {
+            StringVector.Builder sb = new StringVector.Builder();
+            DatabaseMetaData dbm = con.getMetaData();
+            ResultSet rsm = dbm.getTables(con.getCatalog(), null, null, types);
 
-  /*
-   * this is required because Renjn's property accessor fails on the Oracle JDBC
-   * driver
-   */
-  public static ResultSet gimmeResults(Statement s) {
-    try {
-      return s.getResultSet();
-    } catch (SQLException e) {
+            while (rsm.next()) {
+                sb.add(rsm.getString("TABLE_NAME"));
+            }
+            rsm.close();
+            return sb.build();
+        } catch (SQLException e) {
+            throw new EvalException(e);
+        }
     }
-    return null;
-  }
+
+    /**
+     * List the name of the columns for a table
+     *
+     * @param con the connection to the database
+     * @param table the table name
+     * @return StringVector
+     */
+    public static StringVector getColumns(Connection con, String table) {
+        try {
+            StringVector.Builder sb = new StringVector.Builder();
+            DatabaseMetaData dbm = con.getMetaData();
+            ResultSet rsm = dbm.getColumns(con.getCatalog(), null, table, null);
+            while (rsm.next()) {
+                sb.add(rsm.getString("COLUMN_NAME"));
+            }
+            rsm.close();
+            // try again with an uppercased table name. Hello, Oracle!
+            if (sb.length() < 1) {
+                rsm = dbm.getColumns(con.getCatalog(), null, table.toUpperCase(), null);
+                while (rsm.next()) {
+                    sb.add(rsm.getString("COLUMN_NAME"));
+                }
+                rsm.close();
+            }
+            return sb.build();
+        } catch (SQLException e) {
+            throw new EvalException(e);
+        }
+    }
+
+    /**
+     * Returns the name and the SQL data type for each column of a table
+     *
+     * @param rs
+     * @return ListVector
+     */
+    public static ListVector columnInfo(ResultSet rs) {
+        try {
+            ListVector.Builder tv = new ListVector.Builder();
+            ResultSetMetaData rsm = rs.getMetaData();
+            for (int i = 1; i < rsm.getColumnCount() + 1; i++) {
+                ListVector.NamedBuilder cv = new ListVector.NamedBuilder();
+                cv.add("name", rsm.getColumnName(i));
+                cv.add("type", rsm.getColumnTypeName(i));
+                tv.add(cv.build());
+            }
+            return tv.build();
+        } catch (SQLException e) {
+            throw new EvalException(e);
+        }
+    }
+
+    /**
+     * This is required because Renjn's property accessor fails on the Oracle
+     * JDBC driver
+     * @param s
+     * @return 
+     */
+    public static ResultSet gimmeResults(Statement s) {
+        try {
+            return s.getResultSet();
+        } catch (SQLException e) {
+        }
+        return null;
+    }
   
-  /* same as above */
-  public static void toggleAutocommit(Connection c, boolean newState) {
-    try {
-      c.setAutoCommit(newState);
-    } catch (SQLException e) {
-      throw new EvalException(e);
-    }
-  }
-
-  public static ListVector fetch(ResultSet rs, long n) {
-    try {
-      if (n < 0) {
-        n = Long.MAX_VALUE;
-      }
-      ListVector columnVector = columnInfo(rs);
-
-      int numColumns = columnVector.length();
-
-      /* column builders */
-      List<ColumnBuilder> builders = new ArrayList<ColumnBuilder>();
-      for (int i = 0; i < numColumns; i++) {
-        ListVector columnInfo = (ListVector) columnVector.get(i);
-        String columnType = columnInfo.get("type").asString().toLowerCase();
-        
-        if (BigIntColumnBuilder.acceptsType(columnType)) {
-          builders.add(new BigIntColumnBuilder());
-          
-        } else if (IntColumnBuilder.acceptsType(columnType)) {
-          builders.add(new IntColumnBuilder());
-
-        } else if (DoubleColumnBuilder.acceptsType(columnType)) {
-          builders.add(new DoubleColumnBuilder());
-        
-        } else if (LogicalColumnBuilder.acceptsType(columnType)) {
-          builders.add(new LogicalColumnBuilder());
-
-        } else if (StringColumnBuilder.acceptsType(columnType)) {
-          builders.add(new StringColumnBuilder());
-          
-        } else if (DateStringColumnBuilder.acceptsType(columnType)) {
-          builders.add(new DateStringColumnBuilder(ISODateTimeFormat.dateTime()));
-
-        } else {
-          throw new EvalException("Unknown column type " + columnInfo);
+    /**
+     * Same as above
+     * @param c
+     * @param newState
+     */
+    public static void toggleAutocommit(Connection c, boolean newState) {
+        try {
+            c.setAutoCommit(newState);
+        } catch (SQLException e) {
+            throw new EvalException(e);
         }
-      }
-
-      long rows = 0;
-      /* collect values */
-      while (n > 0 && rs.next()) {
-        for (int i = 0; i < numColumns; i++) {
-          builders.get(i).addValue(rs, i+1);
-        }
-        rows++;
-        n--;
-      }
-      /* call build() on each column and add them as named cols to df */
-      ListVector.NamedBuilder dataFrame = new ListVector.NamedBuilder();
-      for (int i = 0; i < numColumns; i++) {
-        ListVector ci = (ListVector) columnVector.get(i);
-        dataFrame.add(ci.get("name").asString(), builders.get(i).build());
-      }
-      dataFrame.setAttribute("row.names", new RowNamesVector((int)rows));
-      dataFrame.setAttribute("class", StringVector.valueOf("data.frame"));
-      return dataFrame.build();
-
-    } catch (SQLException e) {
-      throw new EvalException(e);
     }
-  }
+
+    /**
+     * Fetch the columns and row values into Renjin datatypes
+     * @param rs
+     * @param n
+     * @return
+     */
+    public static ListVector fetch(ResultSet rs, long n) {
+        try {
+            if (n < 0) {
+                n = Long.MAX_VALUE;
+            }
+            ListVector columnVector = columnInfo(rs);
+
+            int numColumns = columnVector.length();
+
+            /* column builders */
+            List<ColumnBuilder> builders = new ArrayList<ColumnBuilder>();
+            for (int i = 0; i < numColumns; i++) {
+                ListVector columnInfo = (ListVector) columnVector.get(i);
+                String columnType = columnInfo.get("type").asString().toLowerCase();
+
+                if (BigIntColumnBuilder.acceptsType(columnType)) {
+                    builders.add(new BigIntColumnBuilder());
+
+                } else if (IntColumnBuilder.acceptsType(columnType)) {
+                    builders.add(new IntColumnBuilder());
+
+                } else if (DoubleColumnBuilder.acceptsType(columnType)) {
+                    builders.add(new DoubleColumnBuilder());
+
+                } else if (LogicalColumnBuilder.acceptsType(columnType)) {
+                    builders.add(new LogicalColumnBuilder());
+
+                } else if (StringColumnBuilder.acceptsType(columnType)) {
+                    builders.add(new StringColumnBuilder());
+
+                } else if (DateStringColumnBuilder.acceptsType(columnType)) {
+                    builders.add(new DateStringColumnBuilder(ISODateTimeFormat.dateTime()));
+
+                } else {
+                    throw new EvalException("Unknown column type " + columnInfo);
+                }
+            }
+
+            long rows = 0;
+            /* collect values */
+            while (n > 0 && rs.next()) {
+                for (int i = 0; i < numColumns; i++) {
+                    builders.get(i).addValue(rs, i + 1);
+                }
+                rows++;
+                n--;
+            }
+            /* call build() on each column and add them as named cols to df */
+            ListVector.NamedBuilder dataFrame = new ListVector.NamedBuilder();
+            for (int i = 0; i < numColumns; i++) {
+                ListVector ci = (ListVector) columnVector.get(i);
+                dataFrame.add(ci.get("name").asString(), builders.get(i).build());
+            }
+            dataFrame.setAttribute("row.names", new RowNamesVector((int) rows));
+            dataFrame.setAttribute("class", StringVector.valueOf("data.frame"));
+            return dataFrame.build();
+
+        } catch (SQLException e) {
+            throw new EvalException(e);
+        }
+    }
 
 }

--- a/RH2/NAMESPACE
+++ b/RH2/NAMESPACE
@@ -1,3 +1,4 @@
 import(DBI)
 importClass(org.h2.Driver)
+importClass(org.renjin.cran.DBI.JDBCUtils)
 exportPattern("^[^\\.]")

--- a/RH2/pom.xml
+++ b/RH2/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.192</version>
+            <version>1.4.196</version>
         </dependency>
     </dependencies>
 

--- a/RH2/src/main/R/h2.R
+++ b/RH2/src/main/R/h2.R
@@ -4,3 +4,90 @@ RH2 <- H2 <- function() {
 
 # load DBI to replicate GNU R 'Depends:'
 .onLoad <- function(libname, pkgname) library(DBI)
+
+
+###Override DBI functions to support custom table data types
+
+dbListTables      <- function(con, ...)       UseMethod("dbListTables") 
+dbListTables <- function(con) {
+    JDBCUtils$getTables(con$conn,c("TABLE", "VIEW", "TABLE LINK", "EXTERNAL")) 
+}
+
+dbExistsTable      <- function(con, ...)       UseMethod("dbExistsTable") 
+dbExistsTable.JDBCConnection <- function(con, name, ...) {
+	tolower(gsub("(^\"|\"$)","",as.character(name))) %in% 
+			tolower(dbListTables(con))
+}
+
+dbRemoveTable      <- function(con, ...)       UseMethod("dbRemoveTable")
+dbRemoveTable.JDBCConnection <- function(con, name, ...) {
+	if (dbExistsTable(con, name)) {
+		dbSendUpdate(con, paste("DROP TABLE", tolower(name)))
+		return(invisible(TRUE))
+	}
+	invisible(FALSE)
+}
+
+dbReadTable      <- function(con, ...)       UseMethod("dbReadTable")
+dbReadTable.JDBCConnection <- function(con, name, ...) {
+	if (!dbExistsTable(con, name))
+		stop(paste0("Unknown table: ", name));
+	dbGetQuery(con,paste0("SELECT * FROM ", name))
+}
+
+dbWriteTable      <- function(con, ...)       UseMethod("dbWriteTable")
+dbWriteTable.JDBCConnection <- function(conn, name, value, overwrite=FALSE, 
+		append=FALSE, csvdump=FALSE, transaction=TRUE, ...) {
+	if (is.vector(value) && !is.list(value)) value <- data.frame(x=value)
+	if (length(value)<1) stop("value must have at least one column")
+	if (is.null(names(value))) names(value) <- paste("V", 1:length(value), sep='')
+	if (length(value[[1]])>0) {
+		if (!is.data.frame(value)) value <- as.data.frame(value, row.names=1:length(value[[1]]))
+	} else {
+		if (!is.data.frame(value)) value <- as.data.frame(value)
+	}
+	if (overwrite && append) {
+		stop("Setting both overwrite and append to true makes no sense.")
+	}
+	qname <- make.db.names(conn, name)
+	if (dbExistsTable(conn, qname)) {
+		if (overwrite) dbRemoveTable(conn, qname)
+		if (!overwrite && !append) stop("Table ", qname, " already exists. Set overwrite=TRUE if you want 
+							to remove the existing table. Set append=TRUE if you would like to add the new data to the 
+							existing table.")
+	}
+	if (!dbExistsTable(conn, qname)) {
+		fts <- sapply(value, function(x) {
+					dbDataType(conn, x)
+				})
+		fdef <- paste(make.db.names(conn, tolower(names(value))), fts, collapse=', ')
+		ct <- paste("CREATE TABLE ", qname, " (", fdef, ")", sep= '')
+		dbSendUpdate(conn, ct)
+	}
+	if (length(value[[1]])) {
+		vins <- paste("(", paste(rep("?", length(value)), collapse=', '), ")", sep='')
+
+		if (transaction) dbBegin(conn)
+		# chunk some inserts together so we do not need to do a round trip for every one
+		splitlen <- 0:(nrow(value)-1) %/% getOption("dbi.insert.splitsize", 1000)
+
+		lapply(split(value, splitlen), 
+				function(valueck) {
+					bvins <- c()
+					for (j in 1:length(valueck[[1]])) {
+						bvins <- c(bvins, .bindParameters(conn, vins, as.list(valueck[j, ])))
+                                                                                                
+					} 
+					dbSendUpdate(conn, paste0("INSERT INTO ", qname, " VALUES ",paste0(bvins, collapse=", ")))
+				})
+		if (transaction) dbCommit(conn)		
+	}
+	invisible(TRUE)
+}
+
+dbListFields      <- function(con, ...)       UseMethod("dbListFields")
+dbListFields.JDBCConnection <- function(con, name, ...) {
+	if (!dbExistsTable(con, name))
+		stop("Unknown table ", name);
+	JDBCUtils$getColumns(con$conn, name)	
+}

--- a/RH2/src/test/R/h2-test.R
+++ b/RH2/src/test/R/h2-test.R
@@ -2,6 +2,9 @@ library(hamcrest)
 library(RH2)
 
 test.driver <- function() {
-	con <- dbConnect(RH2(), url="jdbc:h2:file:/tmp/db", username="sa", password="")
+        dbPath = paste (tempdir(), "/h2", sep = "", collapse = NULL)
+        unlink(dbPath, recursive = FALSE, force = FALSE)
+        dbUrl = paste ("jdbc:h2:file:",dbPath,"/db_external", sep = "", collapse = NULL)
+	con <- dbConnect(RH2(), url=dbUrl, username="sa", password="")
 	renjinDBITest(con)
 }

--- a/RH2GIS/NAMESPACE
+++ b/RH2GIS/NAMESPACE
@@ -1,3 +1,4 @@
 import(DBI)
 importClass(org.h2.Driver)
+importClass(org.renjin.cran.DBI.JDBCUtils)
 exportPattern("^[^\\.]")

--- a/RH2GIS/pom.xml
+++ b/RH2GIS/pom.xml
@@ -22,7 +22,7 @@
 	<dependency>
             <groupId>org.orbisgis</groupId>
             <artifactId>h2gis-ext</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1</version>
             <type>jar</type>
 	</dependency>
     </dependencies>

--- a/RH2GIS/src/main/R/h2gis.R
+++ b/RH2GIS/src/main/R/h2gis.R
@@ -6,6 +6,93 @@ RH2GIS <- H2GIS <- function() {
 .onLoad <- function(libname, pkgname) library(DBI)
 
 
+###Override DBI functions to support custom table data types
+
+dbListTables      <- function(con, ...)       UseMethod("dbListTables") 
+dbListTables <- function(con) {
+    JDBCUtils$getTables(con$conn,c("TABLE", "VIEW", "TABLE LINK", "EXTERNAL")) 
+}
+
+dbExistsTable      <- function(con, ...)       UseMethod("dbExistsTable") 
+dbExistsTable.JDBCConnection <- function(con, name, ...) {
+	tolower(gsub("(^\"|\"$)","",as.character(name))) %in% 
+			tolower(dbListTables(con))
+}
+
+dbRemoveTable      <- function(con, ...)       UseMethod("dbRemoveTable")
+dbRemoveTable.JDBCConnection <- function(con, name, ...) {
+	if (dbExistsTable(con, name)) {
+		dbSendUpdate(con, paste("DROP TABLE", tolower(name)))
+		return(invisible(TRUE))
+	}
+	invisible(FALSE)
+}
+
+dbReadTable      <- function(con, ...)       UseMethod("dbReadTable")
+dbReadTable.JDBCConnection <- function(con, name, ...) {
+	if (!dbExistsTable(con, name))
+		stop(paste0("Unknown table: ", name));
+	dbGetQuery(con,paste0("SELECT * FROM ", name))
+}
+
+dbWriteTable      <- function(con, ...)       UseMethod("dbWriteTable")
+dbWriteTable.JDBCConnection <- function(conn, name, value, overwrite=FALSE, 
+		append=FALSE, csvdump=FALSE, transaction=TRUE, ...) {
+	if (is.vector(value) && !is.list(value)) value <- data.frame(x=value)
+	if (length(value)<1) stop("value must have at least one column")
+	if (is.null(names(value))) names(value) <- paste("V", 1:length(value), sep='')
+	if (length(value[[1]])>0) {
+		if (!is.data.frame(value)) value <- as.data.frame(value, row.names=1:length(value[[1]]))
+	} else {
+		if (!is.data.frame(value)) value <- as.data.frame(value)
+	}
+	if (overwrite && append) {
+		stop("Setting both overwrite and append to true makes no sense.")
+	}
+	qname <- make.db.names(conn, name)
+	if (dbExistsTable(conn, qname)) {
+		if (overwrite) dbRemoveTable(conn, qname)
+		if (!overwrite && !append) stop("Table ", qname, " already exists. Set overwrite=TRUE if you want 
+							to remove the existing table. Set append=TRUE if you would like to add the new data to the 
+							existing table.")
+	}
+	if (!dbExistsTable(conn, qname)) {
+		fts <- sapply(value, function(x) {
+					dbDataType(conn, x)
+				})
+		fdef <- paste(make.db.names(conn, tolower(names(value))), fts, collapse=', ')
+		ct <- paste("CREATE TABLE ", qname, " (", fdef, ")", sep= '')
+		dbSendUpdate(conn, ct)
+	}
+	if (length(value[[1]])) {
+		vins <- paste("(", paste(rep("?", length(value)), collapse=', '), ")", sep='')
+
+		if (transaction) dbBegin(conn)
+		# chunk some inserts together so we do not need to do a round trip for every one
+		splitlen <- 0:(nrow(value)-1) %/% getOption("dbi.insert.splitsize", 1000)
+
+		lapply(split(value, splitlen), 
+				function(valueck) {
+					bvins <- c()
+					for (j in 1:length(valueck[[1]])) {
+						bvins <- c(bvins, .bindParameters(conn, vins, as.list(valueck[j, ])))
+                                                                                                
+					} 
+					dbSendUpdate(conn, paste0("INSERT INTO ", qname, " VALUES ",paste0(bvins, collapse=", ")))
+				})
+		if (transaction) dbCommit(conn)		
+	}
+	invisible(TRUE)
+}
+
+dbListFields      <- function(con, ...)       UseMethod("dbListFields")
+dbListFields.JDBCConnection <- function(con, name, ...) {
+	if (!dbExistsTable(con, name))
+		stop("Unknown table ", name);
+	JDBCUtils$getColumns(con$conn, name)	
+}
+
+
 #This function load the H2GIS spatial functions
 loadSpatialFunctions <- function(con){
     if(dbIsValid(con)){

--- a/RH2GIS/src/test/R/h2gis-test.R
+++ b/RH2GIS/src/test/R/h2gis-test.R
@@ -2,8 +2,10 @@ library(hamcrest)
 library(RH2GIS)
 
 test.driver <- function() {
-        dbPath = paste ("jdbc:h2:file:",tempdir(), "/db", sep = "", collapse = NULL)
-        con <- dbConnect(RH2GIS(), url=dbPath, username="sa", password="")
+        dbPath = paste (tempdir(), "/h2gis", sep = "", collapse = NULL)
+        unlink(dbPath, recursive = FALSE, force = FALSE)
+        dbUrl = paste ("jdbc:h2:file:",dbPath,"/db_external", sep = "", collapse = NULL)
+        con <- dbConnect(RH2GIS(), url=dbUrl, username="sa", password="")
 	print(loadSpatialFunctions(con));
         sq <- dbSendQuery(con,"DROP TABLE IF EXISTS VANNES; CREATE TABLE VANNES (the_geom geometry, id int)")
         stopifnot(identical(dbExistsTable(con,"VANNES"),TRUE))

--- a/RH2GIS/src/test/R/h2gis-test.R
+++ b/RH2GIS/src/test/R/h2gis-test.R
@@ -3,10 +3,27 @@ library(RH2GIS)
 
 test.driver <- function() {
         dbPath = paste ("jdbc:h2:file:",tempdir(), "/db", sep = "", collapse = NULL)
-	con <- dbConnect(RH2GIS(), url=dbPath, username="sa", password="")
+        con <- dbConnect(RH2GIS(), url=dbPath, username="sa", password="")
 	print(loadSpatialFunctions(con));
         sq <- dbSendQuery(con,"DROP TABLE IF EXISTS VANNES; CREATE TABLE VANNES (the_geom geometry, id int)")
         stopifnot(identical(dbExistsTable(con,"VANNES"),TRUE))
         sq <- dbSendQuery(con,"INSERT INTO VANNES VALUES('POLYGON ((100 300, 210 300, 210 200, 100 200, 100 300))'::GEOMETRY, 1)"); 
         stopifnot(identical(as.numeric(dbGetQuery(con,"SELECT ST_AREA(the_geom) as area FROM VANNES")[[1]]),11000))
+}
+
+
+test.externalFile <- function() {        
+        dbPath = paste (tempdir(), "/h2gis", sep = "", collapse = NULL)
+        unlink(dbPath, recursive = FALSE, force = FALSE)
+        dbUrl = paste ("jdbc:h2:file:",dbPath,"/db_external", sep = "", collapse = NULL)
+	con <- dbConnect(RH2GIS(), url=dbUrl, username="sa", password="")
+        sq <- dbSendQuery(con,"DROP TABLE IF EXISTS VANNES, LINKED_SHAPE; CREATE TABLE VANNES (the_geom geometry, gid int)")
+        sq <- dbSendQuery(con,"INSERT INTO VANNES VALUES('POLYGON ((100 300, 210 300, 210 200, 100 200, 100 300))'::GEOMETRY, 1)"); 
+        shapeWrite = paste ("CALL SHPWrite('",dbPath, "/vannes.shp', 'VANNES')", sep = "", collapse = NULL)      
+        dbSendQuery(con,shapeWrite);
+        shapeTable = paste ("CALL FILE_TABLE('",dbPath, "/vannes.shp', 'LINKED_SHAPE')", sep = "", collapse = NULL)
+        dbSendQuery(con,shapeTable);
+        stopifnot(identical(dbExistsTable(con,"LINKED_SHAPE"),TRUE))
+        dbRemoveTable(con, "LINKED_SHAPE");
+        stopifnot(identical(dbExistsTable(con,"LINKED_SHAPE"),FALSE))
 }


### PR DESCRIPTION
This PR proposes to extend the method getTables used by the DBI package to custom table types.
By default the DBI function set only one standardized table type

```R
dbListTables.JDBCConnection <- function(con) {
	JDBCUtils$getTables(con$conn,c("TABLE") )
}
```

The RH2 and RH2GIS take profit of this change to implement db-dependent tables types. The table types are implemented both in H2 and H2GIS R loaders and need to override 5 DBI functions. 
Please have a look on h2gis.R and h2.R files.

At the same time, H2 and H2GIS dependencies have been updated and some javadoc added.
